### PR TITLE
 ignoring unnecessarily generated target/symphony directory

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,4 +15,4 @@ jobs:
           cache: 'maven'
       - name: Build with Maven
         run: |
-          mvn install -DskipTests=true -Dmaven.javadoc.skip=true -B -V -Pci
+          mvn install -DskipTests=true -Dmaven.javadoc.skip=true -B -V -Pci -DskipAssembly


### PR DESCRIPTION
In our analysis, we observe that the target/symphony/ directory is generated but not later used during the CI build. Hence, we propose to disable generating this directory to save runtime. 

The generation of this directory can be disabled by simply adding -DskipAssembly to the mvn command.
